### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Firebase
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/devlobaugh-lab/crate-tracker/security/code-scanning/12](https://github.com/devlobaugh-lab/crate-tracker/security/code-scanning/12)

To fix this issue, an explicit `permissions` block should be added to the workflow to restrict the GITHUB_TOKEN as much as possible. Since this workflow only requires reading the repository's contents (to checkout code, build, and deploy), the minimal starting point is to set `permissions: contents: read` at the job or workflow root. This limits the token and helps ensure the workflow adheres to the principle of least privilege. There is no need to grant additional write permissions since the workflow does not push commits, open issues, or perform any repository-modifying actions. No changes to steps or imports are required; simply add the permissions YAML block before or within the `jobs:` section of `.github/workflows/deploy.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
