### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/devlobaugh-lab/crate-tracker/security/code-scanning/10](https://github.com/devlobaugh-lab/crate-tracker/security/code-scanning/10)

To resolve the issue, you should add an explicit `permissions` key restricting GITHUB_TOKEN access. The best way is to add a `permissions` block with only the minimum required privileges—since the workflow does not push or modify the repository, `contents: read` is sufficient. You can add this either at the workflow root (between `name:` and `on:`) to apply to all jobs, or at the job level if certain jobs require customized permissions. In this case, adding the block at the root is clean and future-proof. No new methods or imports are needed.

Edit `.github/workflows/ci.yml` and insert:

```yaml
permissions:
  contents: read
```

immediately after the workflow name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
